### PR TITLE
Fix init for cases when the whole body changes

### DIFF
--- a/src/content/index.jsx
+++ b/src/content/index.jsx
@@ -36,13 +36,12 @@ const init = () => {
   document.body.appendChild(container)
   render(<Main selectionListener={selectionListener} storageListener={storageListener}/>, container)
 
-  const observer = new MutationObserver((mutations) => {
-    const removed = mutations.some(({ removedNodes }) => Array.from(removedNodes).includes(container))
-    if (!removed) return
+  const observer = new MutationObserver(() => {
+    if (!document.body || document.body.contains(container)) return
     observer.disconnect()
     setTimeout(init, reinitDelay)
   })
-  observer.observe(container.parentNode, { childList: true })
+  observer.observe(document, { childList: true })
 }
 
 init()


### PR DESCRIPTION
Hi,

This PR makes the plugin work with DOM changes which remove the plugin's `container` node **but** this is not reflected in the MutationObserver's listener argument.

An example of such a change is replacing the entire `documentElement` via `document.replaceChild(newDocumentElement, document.documentElement)`. If someone (a page's script or another plugin) does this, there will be no mention of the container node, but the node will be gone.